### PR TITLE
Added quotes to parameters of install.packages(). Also added install for png

### DIFF
--- a/tutorials/intro_to_bnlearn.Rmd
+++ b/tutorials/intro_to_bnlearn.Rmd
@@ -15,8 +15,9 @@ knitr::opts_chunk$set(fig.path="fig/")
 Open RStudio and in console type:
 
 ```
-install.packages(bnlearn)
-install.packages(Rgraphviz)
+install.packages("bnlearn")
+install.packages("Rgraphviz")
+install.packages("png")
 ```
 
 If you experience problems installing **Rgraphviz**, try the following script:


### PR DESCRIPTION
The instructions for install.packages() is missing quotation marks. Also, add a command for install.packages() for png